### PR TITLE
optimize build and use a cx11 instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,6 @@
 
 Deploy OKD4 (OpenShift) on Hetzner Cloud with Cloudflare Loadbalancing using Hashicorp Packer and Terraform.
 
-
-
 ## Usage
 
 ### Build toolbox
@@ -92,8 +90,6 @@ export CLOUDFLARE_API_KEY=14758f1afd44c09b7992073ccf00b43d
 ### Create Fedora CoreOS image
 
 Build a Fedora CoreOS hcloud image with Packer and embed the hcloud user data source (`http://169.254.169.254/hetzner/v1/userdata`).
-
-Because the Fedora CoreOS image will be stored in RAM during the build, at least a cx31 instance is required.
 
 ```
 make hcloud_image

--- a/packer/hcloud-fcos.json
+++ b/packer/hcloud-fcos.json
@@ -1,7 +1,7 @@
 {
   "variables": {
     "location": "nbg1",
-    "server_type": "cx31",
+    "server_type": "cx11",
     "snapshot_prefix": "fcos",
     "image_type": "generic",
     "ignition_config": "config.ign"
@@ -27,13 +27,12 @@
     {
       "type": "shell",
       "inline": [
+        "set -x",
         "mkdir /source",
-        "mount -t tmpfs -o size=5G none /source",
+        "mount -t tmpfs -o size=2G none /source",
         "cd /source",
-        "wget -O fedora-coreos-{{user `fcos_release`}}-qemu.x86_64.qcow2.xz https://builds.coreos.fedoraproject.org/prod/streams/{{user `fcos_stream`}}/builds/{{user `fcos_release`}}/x86_64/fedora-coreos-{{user `fcos_release`}}-qemu.x86_64.qcow2.xz",
-        "unxz fedora-coreos-{{user `fcos_release`}}-qemu.x86_64.qcow2.xz",
-        "qemu-img convert fedora-coreos-{{user `fcos_release`}}-qemu.x86_64.qcow2 -O raw fedora-coreos-{{user `fcos_release`}}-qemu.x86_64.raw",
-        "dd if=fedora-coreos-{{user `fcos_release`}}-qemu.x86_64.raw of=/dev/sda bs=128M",
+        "curl -sfL https://builds.coreos.fedoraproject.org/prod/streams/{{user `fcos_stream`}}/builds/{{user `fcos_release`}}/x86_64/fedora-coreos-{{user `fcos_release`}}-qemu.x86_64.qcow2.xz | unxz > fedora-coreos-{{user `fcos_release`}}-qemu.x86_64.qcow2",
+        "qemu-img convert fedora-coreos-{{user `fcos_release`}}-qemu.x86_64.qcow2 -O raw /dev/sda",
         "partprobe /dev/sda",
         "mkdir /target",
         "mount /dev/sda1 /target",
@@ -48,6 +47,7 @@
     {
       "type": "shell",
       "inline": [
+        "set -x",
         "cd /",
         "umount /source",
         "umount /target"


### PR DESCRIPTION
- Download and extract image via `curl | unxz` hack
- The `qemu-img` does not write to disk directly
- Use a cx11 instance for packer, which results in a minimal primary disk
- This allows us to deploy a worker node as e.g. cx11 or cx21