### PR TITLE
remove name argument from dns_srv_etcd

### DIFF
--- a/terraform/dns.tf
+++ b/terraform/dns.tf
@@ -52,16 +52,18 @@ resource "cloudflare_record" "dns_a_etcd" {
 resource "cloudflare_record" "dns_srv_etcd" {
   zone_id = var.dns_zone_id
   name    = "_etcd-server-ssl._tcp.${var.dns_domain}"
+  value   = "0\t2380\tetcd-${count.index}.${var.dns_domain}"
   type    = "SRV"
 
-  data = {
-    service  = "_etcd-server-ssl"
-    proto    = "_tcp"
-    priority = 0
-    weight   = 0
-    port     = 2380
-    target   = "etcd-${count.index}.${var.dns_domain}"
-  }
+  #data = {
+  #  #name      = "${var.dns_domain}."
+  #  service  = "_etcd-server-ssl"
+  #  proto    = "_tcp"
+  #  priority = 0
+  #  weight   = 0
+  #  port     = 2380
+  #  target   = "etcd-${count.index}.${var.dns_domain}"
+  #}
 
   count = length(module.master.ipv4_addresses)
 }

--- a/terraform/dns.tf
+++ b/terraform/dns.tf
@@ -57,7 +57,6 @@ resource "cloudflare_record" "dns_srv_etcd" {
   data = {
     service  = "_etcd-server-ssl"
     proto    = "_tcp"
-    name     = "_etcd-server-ssl._tcp.${var.dns_domain}"
     priority = 0
     weight   = 0
     port     = 2380

--- a/terraform/dns.tf
+++ b/terraform/dns.tf
@@ -55,15 +55,9 @@ resource "cloudflare_record" "dns_srv_etcd" {
   value   = "0\t2380\tetcd-${count.index}.${var.dns_domain}"
   type    = "SRV"
 
-  #data = {
-  #  #name      = "${var.dns_domain}."
-  #  service  = "_etcd-server-ssl"
-  #  proto    = "_tcp"
-  #  priority = 0
-  #  weight   = 0
-  #  port     = 2380
-  #  target   = "etcd-${count.index}.${var.dns_domain}"
-  #}
+  lifecycle {
+    ignore_changes = [data]
+  }
 
   count = length(module.master.ipv4_addresses)
 }


### PR DESCRIPTION
Something has changed in the Cloudflare API, which results in broken SRV records.

This hopefully fixes the issue.