### PR TITLE
Add intial version of firewall feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,14 @@ make fetch build run
 
 Besides that a RedHat OpenShift pull secret is necessary, which could be obtained from [cloud.redhat.com](https://cloud.redhat.com/).
 
+## Enforce Firewall rules
+
+As the Terraform module from Hetzer is currently unable to produce applied rules that contain hosts you deploy at the same time, you have to deploy them afterwards.
+
+In order to do that, you should visit your Hetzner Web Console and apply the `okd-master` firewall rule to all hosts with the label `okd.io/master: true`, the `okd-base` to the label `okd.io/node: true` and `okd-ingress` to all nodes with the `okd.io/ingress: true` label. Since terraform will ignore firewall changes, this should not interfere with your existing state.
+
+Note: This will keep hosts pingable, but isolate them complete from the internet, making the cluster only reachable through the load balancer. If you require direct SSH access, you can add another rule, that you apply nodes that allows access to port 22.
+
 ## Author
 
 - [slauger](https://github.com/slauger)

--- a/terraform/firewall.tf
+++ b/terraform/firewall.tf
@@ -1,0 +1,144 @@
+# https://docs.okd.io/latest/installing/installing_platform_agnostic/installing-platform-agnostic.html#installation-network-connectivity-user-infra_installing-platform-agnostic
+resource "hcloud_firewall" "okd-base" {
+  name = "okd-base"
+  # ICMP is always a good idea
+  #
+  # Network reachability tests
+  rule {
+   direction = "in"
+   protocol  = "icmp"
+   source_ips = [
+      "0.0.0.0/0",
+      "::/0"
+   ]
+  }
+  # Metrics
+  rule {
+      direction       = "in"
+      protocol        = "tcp"
+      port            = 1936
+      source_ips      = [for s in concat(module.master.ipv4_addresses, module.worker.ipv4_addresses, module.bootstrap.ipv4_addresses) : "${s}/32"]
+  }
+  # Host level services, including the node exporter on ports 9100-9101 and the Cluster Version Operator on port 9099.
+  rule {
+      direction       = "in"
+      protocol        = "tcp"
+      port            = "9000-9999"
+      source_ips      = [for s in concat(module.master.ipv4_addresses, module.worker.ipv4_addresses, module.bootstrap.ipv4_addresses) : "${s}/32"]
+  }
+  # The default ports that Kubernetes reserves
+  rule {
+      direction       = "in"
+      protocol        = "tcp"
+      port            = "10250-10259"
+      source_ips      = [for s in concat(module.master.ipv4_addresses, module.worker.ipv4_addresses, module.bootstrap.ipv4_addresses) : "${s}/32"]
+  }
+  # openshift-sdn
+  rule {
+      direction       = "in"
+      protocol        = "tcp"
+      port            = "10256"
+      source_ips      = [for s in concat(module.master.ipv4_addresses, module.worker.ipv4_addresses, module.bootstrap.ipv4_addresses) : "${s}/32"]
+  }
+  # VXLAN and Geneve
+  rule {
+      direction       = "in"
+      protocol        = "udp"
+      port            = "4789"
+      source_ips      = [for s in concat(module.master.ipv4_addresses, module.worker.ipv4_addresses, module.bootstrap.ipv4_addresses) : "${s}/32"]
+  }
+  # VXLAN and Geneve
+  rule {
+      direction       = "in"
+      protocol        = "udp"
+      port            = "6081"
+      source_ips      = [for s in concat(module.master.ipv4_addresses, module.worker.ipv4_addresses, module.bootstrap.ipv4_addresses) : "${s}/32"]
+  }
+  # Host level services, including the node exporter on ports 9100-9101.
+  rule {
+      direction       = "in"
+      protocol        = "udp"
+      port            = "9000-9999"
+      source_ips      = [for s in concat(module.master.ipv4_addresses, module.worker.ipv4_addresses, module.bootstrap.ipv4_addresses) : "${s}/32"]
+  }
+  # Kubernetes node port
+  rule {
+      direction       = "in"
+      protocol        = "tcp"
+      port            = "30000-32767"
+      source_ips      = [for s in concat(module.master.ipv4_addresses, module.worker.ipv4_addresses, module.bootstrap.ipv4_addresses) : "${s}/32"]
+  }
+  # Kubernetes node port
+  rule {
+      direction       = "in"
+      protocol        = "udp"
+      port            = "30000-32767"
+      source_ips      = [for s in concat(module.master.ipv4_addresses, module.worker.ipv4_addresses, module.bootstrap.ipv4_addresses) : "${s}/32"]
+  }
+}
+
+
+resource "hcloud_firewall" "okd-master" {
+  name = "okd-master"
+
+  # ICMP is always a good idea
+  #
+  # Network reachability tests
+  rule {
+   direction = "in"
+   protocol  = "icmp"
+   source_ips = [
+      "0.0.0.0/0",
+      "::/0"
+   ]
+  }
+  # Kubernetes API
+  rule {
+      direction       = "in"
+      protocol        = "tcp"
+      port            = "6443"
+      source_ips      = [for s in concat([hcloud_load_balancer.lb.ipv4],module.master.ipv4_addresses, module.worker.ipv4_addresses, module.bootstrap.ipv4_addresses) : "${s}/32"]
+  }
+  # Machine config server
+  rule {
+      direction       = "in"
+      protocol        = "tcp"
+      port            = "22623"
+      source_ips      = [for s in concat([hcloud_load_balancer.lb.ipv4]) : "${s}/32"]
+  }
+  # etcd server and peer ports
+  rule {
+      direction       = "in"
+      protocol        = "tcp"
+      port            = "2379-2380"
+      source_ips      = [for s in module.master.ipv4_addresses : "${s}/32"]
+  }
+}
+
+resource "hcloud_firewall" "okd-ingress" {
+  name = "okd-ingress"
+
+  # ICMP is always a good idea
+  #
+  # Network reachability tests
+  rule {
+   direction = "in"
+   protocol  = "icmp"
+   source_ips = [
+      "0.0.0.0/0",
+      "::/0"
+   ]
+  }
+  rule {
+      direction       = "in"
+      protocol        = "tcp"
+      port            = "80"
+      source_ips      = [for s in [hcloud_load_balancer.lb.ipv4] : "${s}/32"]
+  }
+  rule {
+      direction       = "in"
+      protocol        = "tcp"
+      port            = "443"
+      source_ips      = [for s in [hcloud_load_balancer.lb.ipv4] : "${s}/32"]
+  }
+}

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -38,6 +38,13 @@ module "master" {
   image           = data.hcloud_image.image.id
   image_name      = var.image
   server_type     = "cx41"
+  labels          = {
+    "okd.io/node" = "true",
+    "okd.io/master" = "true",
+    "okd.io/ingress" = "true"
+  }
+  # Manually add apply_to for the labels, until tf_hcloud allows apply_to in the firewall
+  # firewall_ids    = [hcloud_firewall.okd-base.id, hcloud_firewall.okd-master.id, hcloud_firewall.okd-ingress.id]
   subnet          = hcloud_network_subnet.subnet.id
   ignition_url    = "https://api-int.${var.dns_domain}:22623/config/master"
   ignition_cacert = local.ignition_master_cacert
@@ -54,6 +61,13 @@ module "worker" {
   image           = data.hcloud_image.image.id
   image_name      = var.image
   server_type     = "cx41"
+  labels          = {
+    "okd.io/node" = "true",
+    "okd.io/ingress" = "true"
+    "okd.io/worker" = "true"
+  }
+  # Manually add apply_to for the labels, until tf_hcloud allows apply_to in the firewall
+  # firewall_ids    = [hcloud_firewall.okd-base.id, hcloud_firewall.okd-ingress.id]
   subnet          = hcloud_network_subnet.subnet.id
   ignition_url    = "https://api-int.${var.dns_domain}:22623/config/worker"
   ignition_cacert = local.ignition_worker_cacert

--- a/terraform/modules/hcloud_coreos/main.tf
+++ b/terraform/modules/hcloud_coreos/main.tf
@@ -7,10 +7,12 @@ resource "hcloud_server" "server" {
   ssh_keys    = var.ssh_keys
   user_data   = data.template_file.ignition_config[count.index].rendered
   location    = var.location
+  labels      = var.labels
   backups     = var.backups
-  #  lifecycle {
-  #    ignore_changes = [user_data, image]
-  #  }
+  firewall_ids = var.firewall_ids
+  lifecycle {
+    ignore_changes = [user_data, image, firewall_ids]
+  }
 }
 
 resource "hcloud_rdns" "dns-ptr-ipv4" {

--- a/terraform/modules/hcloud_coreos/variables.tf
+++ b/terraform/modules/hcloud_coreos/variables.tf
@@ -59,10 +59,22 @@ variable "location" {
   default     = "nbg1"
 }
 
+variable "labels" {
+  type        = map(string)
+  description = "Labels that the instance is tagged with."
+  default     = {}
+}
+
 variable "backups" {
   type        = bool
   description = "Enable or disable backups"
   default     = false
+}
+
+variable "firewall_ids" {
+  type        = list(number)
+  description = "Assigned firewalls"
+  default     = []
 }
 
 variable "volume" {

--- a/terraform/versions.tf
+++ b/terraform/versions.tf
@@ -6,7 +6,7 @@ terraform {
     }
     hcloud = {
       source  = "hetznercloud/hcloud"
-      version = "1.23.0"
+      version = "1.27.2"
     }
     template = {
       source  = "hashicorp/template"


### PR DESCRIPTION
This patch provides an initial firewall configuration that provides
complete isolation of the cluster from the outside world. The only way
to access the cluster is through the load balancer on ports 6443 (api),
443 (https), 80 (http) and currently 22623 (ignition). Sadly, we can't
automatically apply these firewalls to hosts, since the hcloud terraform
module has a bootstrapping problem[1], so this has to be done afterwards
manually using the Webinterface or CLI. Since all instances are tagged
already, it should be trivial to apply the right firewall rules based on
the tag.

Note on 22623, exposing this port through the loadbalancer permentently
to the internet is not ideal and should be changed. However, I haven't
come up with a better solution. This will be sorted out in the long run.

[1]: https://github.com/hetznercloud/terraform-provider-hcloud/issues/336