### PR TITLE
Update ignition.ign

### DIFF
--- a/terraform/modules/hcloud_coreos/templates/ignition.ign
+++ b/terraform/modules/hcloud_coreos/templates/ignition.ign
@@ -42,6 +42,7 @@
       {
         "filesystem": "root",
         "group": {},
+        "overwrite": true,
         "path": "/etc/resolv.conf",
         "user": {},
         "contents": {


### PR DESCRIPTION
With Ignition 3.0 overwrite defaults to false: https://coreos.github.io/ignition/migrating-configs/#files-now-default-to-overwritefalse The current coreos already has a link under `/sysroot/etc/resolv.conf`. This in combination results in #245.

Adding overwrite=true resolves this problem.