### PR TITLE
Update the Ubuntu images used to 22.04

### DIFF
--- a/packer/hcloud-fcos.json
+++ b/packer/hcloud-fcos.json
@@ -9,7 +9,7 @@
   "builders": [
     {
       "type": "hcloud",
-      "image": "ubuntu-18.04",
+      "image": "ubuntu-22.04",
       "location": "{{user `location`}}",
       "server_type": "{{user `server_type`}}",
       "ssh_username": "root",

--- a/packer/hcloud-rhcos.json
+++ b/packer/hcloud-rhcos.json
@@ -9,7 +9,7 @@
   "builders": [
     {
       "type": "hcloud",
-      "image": "ubuntu-18.04",
+      "image": "ubuntu-22.04",
       "location": "{{user `location`}}",
       "server_type": "{{user `server_type`}}",
       "ssh_username": "root",

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -5,7 +5,7 @@ module "ignition" {
   name           = "ignition"
   dns_domain     = var.dns_domain
   dns_zone_id    = var.dns_zone_id
-  image          = "ubuntu-20.04"
+  image          = "ubuntu-22.04"
   user_data      = file("templates/cloud-init.tpl")
   ssh_keys       = data.hcloud_ssh_keys.all_keys.ssh_keys.*.name
   server_type    = "cx11"

--- a/terraform/modules/hcloud_coreos/variables.tf
+++ b/terraform/modules/hcloud_coreos/variables.tf
@@ -33,7 +33,7 @@ variable "server_type" {
 variable "image" {
   type        = string
   description = "Hetzner Cloud system image"
-  default     = "ubuntu-18.04"
+  default     = "ubuntu-22.04"
 }
 
 variable "user_data" {

--- a/terraform/modules/hcloud_instance/variables.tf
+++ b/terraform/modules/hcloud_instance/variables.tf
@@ -33,7 +33,7 @@ variable "server_type" {
 variable "image" {
   type        = string
   description = "Hetzner Cloud system image"
-  default     = "ubuntu-18.04"
+  default     = "ubuntu-22.04"
 }
 
 variable "user_data" {


### PR DESCRIPTION
Ubuntu 18.04 images are not available anymore on hcloud, bump the version to 22.04 which is the newest currently available and works fine.